### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/LedIndicator/keywords.txt
+++ b/LedIndicator/keywords.txt
@@ -6,33 +6,33 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-LedIndicator		  KEYWORD1
+LedIndicator	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 
-H		 	KEYWORD2
-L		 	KEYWORD2
-P	      	 	KEYWORD2
-U	      	 	KEYWORD2
-oUp	       	 	KEYWORD2
-oDn	      	 	KEYWORD2
-PinsOut	       	 	KEYWORD2
-A	      	 	KEYWORD2
-b	      	 	KEYWORD2
-C               	KEYWORD2
-d               	KEYWORD2
-E               	KEYWORD2
-f	      	 	KEYWORD2
-G	      	 	KEYWORD2
-J	      	 	KEYWORD2
-Off	      	 	KEYWORD2
-PrintNum     	 	KEYWORD2
-setPins			KEYWORD2
+H	KEYWORD2
+L	KEYWORD2
+P	KEYWORD2
+U	KEYWORD2
+oUp	KEYWORD2
+oDn	KEYWORD2
+PinsOut	KEYWORD2
+A	KEYWORD2
+b	KEYWORD2
+C	KEYWORD2
+d	KEYWORD2
+E	KEYWORD2
+f	KEYWORD2
+G	KEYWORD2
+J	KEYWORD2
+Off	KEYWORD2
+PrintNum	KEYWORD2
+setPins	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-rup LITERAL1
+rup	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords